### PR TITLE
Feature JENKINS-29939: repo password encryption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,14 @@
         <lombok.plugin.version>1.12.2.0</lombok.plugin.version>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>1.9.1</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/main/lombok/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition.java
+++ b/src/main/lombok/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition.java
@@ -27,7 +27,6 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.cli.CLICommand;
 import hudson.model.Hudson;
-import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
@@ -58,6 +57,7 @@ import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 
 import lombok.Getter;
+import lombok.Setter;
 import net.sf.json.JSONObject;
 
 import org.apache.commons.codec.binary.Base64;
@@ -73,8 +73,8 @@ import org.kohsuke.stapler.StaplerRequest;
  * @author Gesh Markov &lt;gesh@markov.eu&gt;
  */
 @Getter
-public class MavenMetadataParameterDefinition extends ParameterDefinition {
-  private static final long    serialVersionUID     = -4595893939123446454L;
+public class MavenMetadataParameterDefinition extends MavenMetadataParameterDefinitionBackwardCompatibility {
+  private static final long    serialVersionUID     = -4776115854285459316L;
 
   private static final String  DEFAULT_FIRST        = "FIRST";
   private static final String  DEFAULT_LAST         = "LAST";
@@ -95,7 +95,7 @@ public class MavenMetadataParameterDefinition extends ParameterDefinition {
   private final SortOrder      sortOrder;
   private final String         maxVersions;
 
-  private final String         credentialsId;
+  private @Setter String       credentialsId;
 
   @DataBoundConstructor
   public MavenMetadataParameterDefinition(String name, String description, String repoBaseUrl, String groupId,
@@ -344,7 +344,8 @@ public class MavenMetadataParameterDefinition extends ParameterDefinition {
     return conn;
   }
 
-  private UsernamePasswordCredentials findCredentialsByCredentialsId() {
+  @Override
+  protected UsernamePasswordCredentials findCredentialsByCredentialsId() {
     List<UsernamePasswordCredentials> credentials =
         CredentialsProvider.lookupCredentials(UsernamePasswordCredentials.class, Hudson.getInstance(), ACL.SYSTEM, new DomainRequirement());
     CredentialsMatcher credentialsIdMatcher = CredentialsMatchers.withId(this.credentialsId);

--- a/src/main/lombok/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionBackwardCompatibility.java
+++ b/src/main/lombok/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionBackwardCompatibility.java
@@ -1,0 +1,128 @@
+package eu.markov.jenkins.plugin.mvnmeta;
+
+import hudson.model.Hudson;
+import hudson.model.ParameterDefinition;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Logger;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+
+import lombok.Getter;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * This class contains the members that used to be in {@link MavenMetadataParameterDefinition} and
+ * are now deprecated. Moving deprecated stuff to this class keeps the main implementation cleaner.
+ * <p>
+ * Inspired by <i>hudson.plugins.git.GitSCMBackwardCompatibility</i>
+ * </p>
+ *
+ * @author Marc Rohlfs, Silpion IT-Solutions GmbH - <a href="mailto:rohlfs@silpion.de">rohlfs@silpion.de</a>
+ */
+@Getter
+@SuppressWarnings("deprecation")
+public abstract class MavenMetadataParameterDefinitionBackwardCompatibility extends ParameterDefinition {
+  private static final long serialVersionUID = -694351540106684393L;
+
+  private static final Logger LOGGER = Logger.getLogger(MavenMetadataParameterDefinition.class.getName());
+
+  /** @deprecated Migrated to {@link MavenMetadataParameterDefinition#credentialsId} */
+  @Deprecated
+  private transient String username;
+
+  /** @deprecated Migrated to {@link MavenMetadataParameterDefinition#credentialsId} */
+  @Deprecated
+  private transient String password;
+
+  public MavenMetadataParameterDefinitionBackwardCompatibility(String name, String description) {
+    super(name, description);
+  }
+
+  public Object readResolve() throws IOException {
+
+    // Migrate username and password to global Jenkins credentials.
+    if (StringUtils.isBlank(this.getCredentialsId()) && StringUtils.isNotBlank(this.username) && StringUtils.isNotBlank(this.password)) {
+      try {
+        this.migrateCredentials();
+      } catch (IOException ioe) {
+        // If a problem occured during migration, a reference to credentials that may not exist must not be stored.
+        this.setCredentialsId(null);
+        LOGGER.warning("Credentials for repo " + this.getRepoBaseUrl() + " and user " + this.username + " could not be migrated");
+      }
+    }
+
+    return this;
+  }
+
+  private void migrateCredentials() throws IOException {
+
+    // The credentials ID doesn't need to be a UUID. Using the repository URL with implicit user
+    // seems to be a good way to identify and reuse credentials, that have already been created by
+    // this migration implementation for another job that connects to the same Maven repository.
+    String repoBaseUrl = this.getRepoBaseUrl();
+    String customCredentialsId;
+    try {
+      customCredentialsId = this.createRepoBaseUrlWithImplicitUser();
+    } catch (MalformedURLException e) {
+      // A problem here should not fail the migration.
+      customCredentialsId = this.username + "@" + repoBaseUrl;
+    }
+    this.setCredentialsId(customCredentialsId);
+
+    // Find previously generated credentials or generate new ones and at them to the global domain.
+    UsernamePasswordCredentials credentials = this.findCredentialsByCredentialsId();
+    if (credentials == null) {
+      String description = "Generated credentials for " + customCredentialsId;
+      credentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, customCredentialsId, description, this.username, this.password);
+
+      CredentialsStore credentialsStore = CredentialsProvider.lookupStores(Hudson.getInstance()).iterator().next();
+      credentialsStore.addCredentials(Domain.global(), credentials);
+    }
+
+    LOGGER.fine("Migrated user " + this.username + " and password for " + repoBaseUrl + " to global credentials with ID " + customCredentialsId);
+  }
+
+  private String createRepoBaseUrlWithImplicitUser() throws MalformedURLException {
+    StringBuilder credentialsIdBuilder = new StringBuilder();
+
+    URL url = new URL(this.getRepoBaseUrl());
+
+    credentialsIdBuilder.append(url.getProtocol());
+    credentialsIdBuilder.append("://");
+    credentialsIdBuilder.append(this.username);
+    credentialsIdBuilder.append("@");
+    credentialsIdBuilder.append(url.getHost());
+
+    int port = url.getPort();
+    if (port > -1) {
+      credentialsIdBuilder.append(":");
+      credentialsIdBuilder.append(port);
+    }
+
+    credentialsIdBuilder.append(url.getPath());
+
+    return credentialsIdBuilder.toString();
+  }
+
+  // NOTE: The main implementation of the MavenMetadataParameterDefinition should not be polluted
+  // with old members or migration code. Methods that are required for main functioality should
+  // remain in the main implementation. To achieve this, this class defines some abstract methods
+  // to members of the main implementation that are required for migrations.
+
+  protected abstract UsernamePasswordCredentials findCredentialsByCredentialsId();
+
+  protected abstract String getRepoBaseUrl();
+
+  protected abstract String getCredentialsId();
+
+  protected abstract void setCredentialsId(final String credentialsId);
+}

--- a/src/main/lombok/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionBackwardCompatibility.java
+++ b/src/main/lombok/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionBackwardCompatibility.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, Silpion IT-Solutions GmbH, Marc Rohlfs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package eu.markov.jenkins.plugin.mvnmeta;
 
 import hudson.model.Hudson;

--- a/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/config.jelly
+++ b/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/config.jelly
@@ -23,7 +23,7 @@
   -->
 
 <!-- this is the page fragment displayed to set up a job -->
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry title="${%Name}" field="name">
         <f:textbox name="parameter.name" value="${instance.name}" />
     </f:entry>
@@ -33,11 +33,8 @@
     <f:entry title="${%Repository Base URL}" field="repoBaseUrl">
         <f:textbox name="parameter.repoBaseUrl" value="${instance.repoBaseUrl}" />
     </f:entry>
-    <f:entry title="${%Repository Username}" field="username">
-        <f:textbox name="parameter.username" value="${instance.username}" />
-    </f:entry>
-    <f:entry title="${%Repository Password}" field="password">
-        <f:password name="parameter.password" value="${instance.password}" />
+    <f:entry title="${%Repository Credentials}" field="credentialsId">
+        <c:select />
     </f:entry>
     <f:entry title="${%Artifact Group ID}" field="groupId">
         <f:textbox name="parameter.groupId" value="${instance.groupId}" />

--- a/src/test/java/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionBackwardCompatibilityTest.java
+++ b/src/test/java/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionBackwardCompatibilityTest.java
@@ -1,0 +1,46 @@
+package eu.markov.jenkins.plugin.mvnmeta;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersDefinitionProperty;
+
+import java.io.InputStream;
+
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Tests the class {@link MavenMetadataParameterDefinitionBackwardCompatibility}.
+ *
+ * @author Marc Rohlfs, Silpion IT-Solutions GmbH - <a href="mailto:rohlfs@silpion.de">rohlfs@silpion.de</a>
+ */
+@SuppressWarnings("deprecation")
+public class MavenMetadataParameterDefinitionBackwardCompatibilityTest {
+
+  @Rule
+  public JenkinsRule jenkinsRule = new JenkinsRule();
+
+  @Test
+  public void testReadResolve() throws Exception {
+
+    // Create the test project from the provided XML file. The migration will implicitly run when the project is created.
+    InputStream projectXmlFile = this.getClass().getResourceAsStream("test-migration.xml");
+    FreeStyleProject testProject = (FreeStyleProject) this.jenkinsRule.jenkins.createProjectFromXML("test-migration", projectXmlFile);
+
+    // Get the migrated build parameter.
+    ParametersDefinitionProperty buildParameters = testProject.getProperty(ParametersDefinitionProperty.class);
+    MavenMetadataParameterDefinition mavenMetadataBuildParameter =
+        (MavenMetadataParameterDefinition) buildParameters.getParameterDefinition("ARTIFACT");
+
+    // Verify the migration of username and password to a generated credentials object.
+    UsernamePasswordCredentials generatedCredentials = mavenMetadataBuildParameter.findCredentialsByCredentialsId();
+    assertNotNull(mavenMetadataBuildParameter.getCredentialsId());
+    assertEquals(generatedCredentials.getUsername(), mavenMetadataBuildParameter.getUsername());
+    assertEquals(generatedCredentials.getPassword().getPlainText(), mavenMetadataBuildParameter.getPassword());
+  }
+}

--- a/src/test/java/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionBackwardCompatibilityTest.java
+++ b/src/test/java/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionBackwardCompatibilityTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, Silpion IT-Solutions GmbH, Marc Rohlfs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package eu.markov.jenkins.plugin.mvnmeta;
 
 import static junit.framework.Assert.assertEquals;

--- a/src/test/java/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionTest.java
+++ b/src/test/java/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionTest.java
@@ -115,21 +115,21 @@ public class MavenMetadataParameterDefinitionTest {
 
     @Test
     public void testSingleSnapshot() {
-        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "single", "jar", "", "DESC", "null", "10", "", "");
+        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "single", "jar", "", "DESC", "null", "10", null);
         MavenMetadataParameterValue result = (MavenMetadataParameterValue) definition.createValue(null, "3.8-SNAPSHOT");
         assertTrue(result.getArtifactUrl(), result.getArtifactUrl().endsWith("3.8-SNAPSHOT.jar"));
     }
 
     @Test
     public void testTimestampedSnapshot() {
-        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "timestamped", "jar", "", "DESC", "null", "10", "", "");
+        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "timestamped", "jar", "", "DESC", "null", "10", null);
         MavenMetadataParameterValue result = (MavenMetadataParameterValue) definition.createValue(null, "3.8-SNAPSHOT");
         assertTrue(result.getArtifactUrl(), result.getArtifactUrl().endsWith("3.8-20140919.030038-76.jar"));
     }
 
     @Test
     public void testListVersionsSingleSnapshot() {
-        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "timestamped", "jar", "", "ASC", "null", "10", "", "");
+        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "timestamped", "jar", "", "ASC", "null", "10", null);
         List<String> versions = definition.getVersions();
         Assert.notEmpty(versions);
         assertEquals("3.6", versions.get(0));
@@ -137,7 +137,7 @@ public class MavenMetadataParameterDefinitionTest {
 
     @Test
     public void testListVersionsTimestampedSnapshot() {
-        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "timestamped", "jar", "", "DESC", "null", "2", "", "");
+        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "timestamped", "jar", "", "DESC", "null", "2", null);
         List<String> versions = definition.getVersions();
         Assert.notEmpty(versions);
         assertEquals(2, versions.size());

--- a/src/test/resources/eu/markov/jenkins/plugin/mvnmeta/test-migration.xml
+++ b/src/test/resources/eu/markov/jenkins/plugin/mvnmeta/test-migration.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions />
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <eu.markov.jenkins.plugin.mvnmeta.MavenMetadataParameterDefinition>
+          <name>ARTIFACT</name>
+          <description></description>
+          <repoBaseUrl>http://repo.jenkins-ci.org/public</repoBaseUrl>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>${project.artifactId}</artifactId>
+          <packaging>${project.packaging}</packaging>
+          <defaultValue></defaultValue>
+          <versionFilter></versionFilter>
+          <sortOrder>DESC</sortOrder>
+          <maxVersions></maxVersions>
+          <username>mybigusername</username>
+          <password>mylittlesecret</password>
+        </eu.markov.jenkins.plugin.mvnmeta.MavenMetadataParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM" />
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers class="vector" />
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers />
+  <buildWrappers />
+</project>


### PR DESCRIPTION
See [JENKINS-29939](https://issues.jenkins-ci.org/browse/JENKINS-29939):

The _Repository Password_ is stored unencrypted in the jobs ``config.xml`` file. I'd suggest to use global Jenkins credentials for repository authentication.

Implementation provides backward compatibility. It migrates old fields ``username`` and ``password`` to new Jenkins credentials.