### PR TITLE
JENKINS-29940: Information about currently used artifact

### DIFF
--- a/src/main/lombok/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition.java
+++ b/src/main/lombok/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition.java
@@ -430,14 +430,14 @@ public class MavenMetadataParameterDefinition extends ParameterDefinition {
   public static class DescriptorImpl extends ParameterDescriptor {
 
     public FormValidation doCheckVersionFilter(@QueryParameter String value) {
-      return this.doCheckRegex(value);
+      return doCheckRegex(value);
     }
 
     public FormValidation doCheckCurrentArtifactInfoPattern(@QueryParameter String value) {
-      return this.doCheckRegex(value);
+      return doCheckRegex(value);
     }
 
-    private FormValidation doCheckRegex(String value) {
+    private static FormValidation doCheckRegex(String value) {
       if (StringUtils.isNotBlank(value)) {
         try {
           Pattern.compile(value);

--- a/src/main/lombok/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition.java
+++ b/src/main/lombok/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition.java
@@ -25,12 +25,11 @@ package eu.markov.jenkins.plugin.mvnmeta;
 
 import hudson.Extension;
 import hudson.Util;
-import hudson.model.ParameterValue;
-import hudson.model.ParameterDefinition;
-import hudson.util.FormValidation;
 import hudson.cli.CLICommand;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
+import hudson.util.FormValidation;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -41,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -65,7 +65,7 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 @Getter
 public class MavenMetadataParameterDefinition extends ParameterDefinition {
-  private static final long    serialVersionUID     = -3820719539319589460L;
+  private static final long    serialVersionUID     = -7884973637623378220L;
 
   private static final String  DEFAULT_FIRST        = "FIRST";
   private static final String  DEFAULT_LAST         = "LAST";
@@ -85,13 +85,17 @@ public class MavenMetadataParameterDefinition extends ParameterDefinition {
   private final String         versionFilter;
   private final SortOrder      sortOrder;
   private final String         maxVersions;
+  private final String         currentArtifactInfoUrl;
+  private final String         currentArtifactInfoLabel;
+  private final String         currentArtifactInfoPattern;
 
   private final String         username;
   private final String         password;
 
   @DataBoundConstructor
   public MavenMetadataParameterDefinition(String name, String description, String repoBaseUrl, String groupId,
-      String artifactId, String packaging, String versionFilter, String sortOrder, String defaultValue, String maxVersions, String username, String password) {
+      String artifactId, String packaging, String versionFilter, String sortOrder, String defaultValue, String maxVersions,
+      String currentArtifactInfoUrl, String currentArtifactInfoLabel, String currentArtifactInfoPattern, String username, String password) {
     super(name, description);
     this.repoBaseUrl = Util.removeTrailingSlash(repoBaseUrl);
     this.groupId = groupId;
@@ -101,6 +105,9 @@ public class MavenMetadataParameterDefinition extends ParameterDefinition {
     this.sortOrder = SortOrder.valueOf(sortOrder);
     this.defaultValue = StringUtils.trim(defaultValue);
     this.maxVersions = maxVersions;
+    this.currentArtifactInfoUrl = currentArtifactInfoUrl;
+    this.currentArtifactInfoLabel = currentArtifactInfoLabel;
+    this.currentArtifactInfoPattern = currentArtifactInfoPattern;
     this.username = username;
     this.password = password;
   }
@@ -206,6 +213,55 @@ public class MavenMetadataParameterDefinition extends ParameterDefinition {
 
   public List<String> getVersions() {
     return getArtifactMetadata().versioning.versions;
+  }
+
+  public String getCurrentArtifactInfo() {
+    StringBuilder currentArtifactInfoBuilder = new StringBuilder("");
+
+    if (StringUtils.isNotBlank(this.currentArtifactInfoUrl)) {
+
+      if (StringUtils.isBlank(this.currentArtifactInfoLabel)) {
+        currentArtifactInfoBuilder.append("Currently used artifact");
+      } else {
+        currentArtifactInfoBuilder.append(this.currentArtifactInfoLabel);
+      }
+      currentArtifactInfoBuilder.append(": ");
+
+      try {
+        currentArtifactInfoBuilder.append(this.getCurrentArtifactInfoInternal());
+      } catch (IOException ioe) {
+        LOGGER.log(Level.WARNING, "Request of current artifact info failed", ioe);
+        currentArtifactInfoBuilder.append("(Request failed)");
+      }
+    }
+
+    return currentArtifactInfoBuilder.toString();
+  }
+
+  private String getCurrentArtifactInfoInternal() throws IOException {
+    String currentArtifactInfo;
+
+    URL url = new URL(this.currentArtifactInfoUrl);
+
+    LOGGER.finest("Requesting current artifact info from URL: " + url.toExternalForm());
+
+    URLConnection connection = url.openConnection();
+    InputStream inputStream = connection.getInputStream();
+    String contentEncoding = connection.getContentEncoding();
+    currentArtifactInfo = IOUtils.toString(inputStream, contentEncoding);
+
+    // When a pattern is configured, use the first match instead of the whole response.
+    if (StringUtils.isNotBlank(this.currentArtifactInfoPattern)) {
+      Pattern pattern = Pattern.compile(this.currentArtifactInfoPattern);
+      Matcher matcher = pattern.matcher(currentArtifactInfo);
+      if (matcher.find()) {
+        // Use only the content of the patterns' first capturing group.
+        // Use the whole match if the pattern doesn't define a caturing group.
+        currentArtifactInfo = matcher.group(Math.min(matcher.groupCount(), 1));
+      }
+    }
+
+    return currentArtifactInfo;
   }
 
   private MavenMetadataVersions getArtifactMetadata() {
@@ -374,6 +430,14 @@ public class MavenMetadataParameterDefinition extends ParameterDefinition {
   public static class DescriptorImpl extends ParameterDescriptor {
 
     public FormValidation doCheckVersionFilter(@QueryParameter String value) {
+      return this.doCheckRegex(value);
+    }
+
+    public FormValidation doCheckCurrentArtifactInfoPattern(@QueryParameter String value) {
+      return this.doCheckRegex(value);
+    }
+
+    private FormValidation doCheckRegex(String value) {
       if (StringUtils.isNotBlank(value)) {
         try {
           Pattern.compile(value);

--- a/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/config.jelly
+++ b/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/config.jelly
@@ -64,4 +64,13 @@
           </j:forEach>
         </select>
     </f:entry> 
+    <f:entry title="${%Current Artifact Info URL}" field="currentArtifactInfoUrl">
+        <f:textbox name="parameter.currentArtifactInfoUrl" value="${instance.currentArtifactInfoUrl}" />
+    </f:entry>
+    <f:entry title="${%Current Artifact Info Label}" field="currentArtifactInfoLabel">
+        <f:textbox name="parameter.currentArtifactInfoLabel" value="${instance.currentArtifactInfoLabel}" />
+    </f:entry>
+    <f:entry title="${%Current Artifact Info Pattern}" field="currentArtifactInfoPattern">
+        <f:textbox name="parameter.currentArtifactInfoPattern" value="${instance.currentArtifactInfoPattern}" />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/help-currentArtifactInfoLabel.html
+++ b/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/help-currentArtifactInfoLabel.html
@@ -1,7 +1,7 @@
 <!--
   - The MIT License
   -
-  - Copyright (c) 2012, AKQA, Georgi "Gesh" Markov
+  - Copyright (c) 2015, Silpion IT-Solutions GmbH, Marc Rohlfs
   -
   - Permission is hereby granted, free of charge, to any person obtaining a copy
   - of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/help-currentArtifactInfoLabel.html
+++ b/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/help-currentArtifactInfoLabel.html
@@ -1,0 +1,29 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2012, AKQA, Georgi "Gesh" Markov
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+
+<div>
+  An informational label that will be displayed in front of the aritfact information.
+  When no label is specified, the default label <i>Currently used artifact</i> will be displayed.
+  Any label will only be displayed when a valid <i>Current Artifact Info URL</i> is configured.
+</div>

--- a/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/help-currentArtifactInfoPattern.html
+++ b/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/help-currentArtifactInfoPattern.html
@@ -1,7 +1,7 @@
 <!--
   - The MIT License
   -
-  - Copyright (c) 2012, AKQA, Georgi "Gesh" Markov
+  - Copyright (c) 2015, Silpion IT-Solutions GmbH, Marc Rohlfs
   -
   - Permission is hereby granted, free of charge, to any person obtaining a copy
   - of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/help-currentArtifactInfoPattern.html
+++ b/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/help-currentArtifactInfoPattern.html
@@ -1,0 +1,30 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2012, AKQA, Georgi "Gesh" Markov
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+
+<div>
+  A pattern that describes the part of the artifact information resources' content to be displayed:
+  <ul>When no pattern is specified, the whole content will be displayed.</ul>
+  <ul>When a standard pattern is specified, only its first match in the content will be displayed.</ul>
+  <ul>When a pattern with a capturing group is specified, only the first group of its first match in the content will be displayed.</ul>
+</div>

--- a/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/help-currentArtifactInfoUrl.html
+++ b/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/help-currentArtifactInfoUrl.html
@@ -1,7 +1,7 @@
 <!--
   - The MIT License
   -
-  - Copyright (c) 2012, AKQA, Georgi "Gesh" Markov
+  - Copyright (c) 2015, Silpion IT-Solutions GmbH, Marc Rohlfs
   -
   - Permission is hereby granted, free of charge, to any person obtaining a copy
   - of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/help-currentArtifactInfoUrl.html
+++ b/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/help-currentArtifactInfoUrl.html
@@ -1,0 +1,29 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2012, AKQA, Georgi "Gesh" Markov
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+
+<div>
+  The URL where an information resource about the currently used artifact can be requested.
+  If the URL is provided and valid, the information will be displayed next to the drop-down.
+  Otherwise not artifact information will be displayed.
+</div>

--- a/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/index.jelly
+++ b/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/index.jelly
@@ -54,6 +54,10 @@
           </select>
         </j:otherwise>
       </j:choose>
+      <j:set var="currentArtifactInfo" value="${it.currentArtifactInfo}"/>
+      <j:if test="${!currentArtifactInfo.isEmpty()}">
+        <span style="padding-left: 20px;">${it.currentArtifactInfo}</span>
+      </j:if>
     </div>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/index.jelly
+++ b/src/main/resources/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition/index.jelly
@@ -56,7 +56,7 @@
       </j:choose>
       <j:set var="currentArtifactInfo" value="${it.currentArtifactInfo}"/>
       <j:if test="${!currentArtifactInfo.isEmpty()}">
-        <span style="padding-left: 20px;">${it.currentArtifactInfo}</span>
+        <span style="padding-left: 20px;">${currentArtifactInfo}</span>
       </j:if>
     </div>
   </f:entry>

--- a/src/test/java/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionTest.java
+++ b/src/test/java/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionTest.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.assertTrue;
 
 public class MavenMetadataParameterDefinitionTest {
 
+    private static final String CURRENT_ARTIFACT_INFO_URL = MavenMetadataParameterDefinitionTest.class.getResource("currentArtifactInfo.txt").toExternalForm();
+
     private ServerSocket server = null;
 
     @Before
@@ -115,21 +117,21 @@ public class MavenMetadataParameterDefinitionTest {
 
     @Test
     public void testSingleSnapshot() {
-        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "single", "jar", "", "DESC", "null", "10", "", "");
+        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "single", "jar", "", "DESC", "null", "10", "", "", "", "", "");
         MavenMetadataParameterValue result = (MavenMetadataParameterValue) definition.createValue(null, "3.8-SNAPSHOT");
         assertTrue(result.getArtifactUrl(), result.getArtifactUrl().endsWith("3.8-SNAPSHOT.jar"));
     }
 
     @Test
     public void testTimestampedSnapshot() {
-        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "timestamped", "jar", "", "DESC", "null", "10", "", "");
+        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "timestamped", "jar", "", "DESC", "null", "10", "", "", "", "", "");
         MavenMetadataParameterValue result = (MavenMetadataParameterValue) definition.createValue(null, "3.8-SNAPSHOT");
         assertTrue(result.getArtifactUrl(), result.getArtifactUrl().endsWith("3.8-20140919.030038-76.jar"));
     }
 
     @Test
     public void testListVersionsSingleSnapshot() {
-        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "timestamped", "jar", "", "ASC", "null", "10", "", "");
+        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "timestamped", "jar", "", "ASC", "null", "10", "", "", "", "", "");
         List<String> versions = definition.getVersions();
         Assert.notEmpty(versions);
         assertEquals("3.6", versions.get(0));
@@ -137,11 +139,46 @@ public class MavenMetadataParameterDefinitionTest {
 
     @Test
     public void testListVersionsTimestampedSnapshot() {
-        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "timestamped", "jar", "", "DESC", "null", "2", "", "");
+        MavenMetadataParameterDefinition definition = new MavenMetadataParameterDefinition("variable", "void", getLocalWebServerUrl(), "com.acme", "timestamped", "jar", "", "DESC", "null", "2", "", "", "", "", "");
         List<String> versions = definition.getVersions();
         Assert.notEmpty(versions);
         assertEquals(2, versions.size());
         assertEquals("3.8-SNAPSHOT", versions.get(0));
     }
 
+    @Test
+    public void testGetCurrentArtifactInfoPatternWithCapturingGroup() {
+        this.testGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, "My Label", "Plugin Version: ([\\S]+)", "My Label: 3.14159");
+    }
+
+    @Test
+    public void testGetCurrentArtifactInfoPatternWithoutCapturingGroup() {
+        this.testGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, "My Label", "Plugin Version: [\\S]+", "My Label: Plugin Version: 3.14159");
+    }
+
+    @Test
+    public void testGetCurrentArtifactInfoWithNonmatchingPattern() {
+        this.testGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, "My Label", "Not Matching: [\\S]+", "My Label: Artifact ID: my-artifact\nPlugin Version: 3.14159\nJenkins Version:  42\n");
+    }
+
+    @Test
+    public void testGetCurrentArtifactInfoWithoutPattern() {
+        this.testGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, "My Label", null, "My Label: Artifact ID: my-artifact\nPlugin Version: 3.14159\nJenkins Version:  42\n");
+    }
+
+    @Test
+    public void testGetCurrentArtifactInfoPatternWithDefaultLabel() {
+        this.testGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, null, "Plugin Version: ([\\S]+)", "Currently used artifact: 3.14159");
+    }
+
+    @Test
+    public void testGetCurrentArtifactInfoPatternWithoutUrl() {
+        this.testGetCurrentArtifactInfoPattern(null, "My Label", "Plugin Version: ([\\S]+)", "");
+    }
+
+    private void testGetCurrentArtifactInfoPattern(String url, String label, String pattern, String expectedResult) {
+        MavenMetadataParameterDefinition definition =
+            new MavenMetadataParameterDefinition("", "", getLocalWebServerUrl(), "", "", "", "", "DESC", "", "", url, label, pattern, "", "");
+        assertEquals(expectedResult, definition.getCurrentArtifactInfo());
+    }
 }

--- a/src/test/java/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionTest.java
+++ b/src/test/java/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinitionTest.java
@@ -148,35 +148,35 @@ public class MavenMetadataParameterDefinitionTest {
 
     @Test
     public void testGetCurrentArtifactInfoPatternWithCapturingGroup() {
-        this.testGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, "My Label", "Plugin Version: ([\\S]+)", "My Label: 3.14159");
+        this.executeTestGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, "My Label", "Plugin Version: ([\\S]+)", "My Label: 3.14159");
     }
 
     @Test
     public void testGetCurrentArtifactInfoPatternWithoutCapturingGroup() {
-        this.testGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, "My Label", "Plugin Version: [\\S]+", "My Label: Plugin Version: 3.14159");
+        this.executeTestGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, "My Label", "Plugin Version: [\\S]+", "My Label: Plugin Version: 3.14159");
     }
 
     @Test
     public void testGetCurrentArtifactInfoWithNonmatchingPattern() {
-        this.testGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, "My Label", "Not Matching: [\\S]+", "My Label: Artifact ID: my-artifact\nPlugin Version: 3.14159\nJenkins Version:  42\n");
+        this.executeTestGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, "My Label", "Not Matching: [\\S]+", "My Label: Artifact ID: my-artifact\nPlugin Version: 3.14159\nJenkins Version:  42\n");
     }
 
     @Test
     public void testGetCurrentArtifactInfoWithoutPattern() {
-        this.testGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, "My Label", null, "My Label: Artifact ID: my-artifact\nPlugin Version: 3.14159\nJenkins Version:  42\n");
+        this.executeTestGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, "My Label", null, "My Label: Artifact ID: my-artifact\nPlugin Version: 3.14159\nJenkins Version:  42\n");
     }
 
     @Test
     public void testGetCurrentArtifactInfoPatternWithDefaultLabel() {
-        this.testGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, null, "Plugin Version: ([\\S]+)", "Currently used artifact: 3.14159");
+        this.executeTestGetCurrentArtifactInfoPattern(CURRENT_ARTIFACT_INFO_URL, null, "Plugin Version: ([\\S]+)", "Currently used artifact: 3.14159");
     }
 
     @Test
     public void testGetCurrentArtifactInfoPatternWithoutUrl() {
-        this.testGetCurrentArtifactInfoPattern(null, "My Label", "Plugin Version: ([\\S]+)", "");
+        this.executeTestGetCurrentArtifactInfoPattern(null, "My Label", "Plugin Version: ([\\S]+)", "");
     }
 
-    private void testGetCurrentArtifactInfoPattern(String url, String label, String pattern, String expectedResult) {
+    private void executeTestGetCurrentArtifactInfoPattern(String url, String label, String pattern, String expectedResult) {
         MavenMetadataParameterDefinition definition =
             new MavenMetadataParameterDefinition("", "", getLocalWebServerUrl(), "", "", "", "", "DESC", "", "", url, label, pattern, "", "");
         assertEquals(expectedResult, definition.getCurrentArtifactInfo());

--- a/src/test/resources/eu/markov/jenkins/plugin/mvnmeta/currentArtifactInfo.txt
+++ b/src/test/resources/eu/markov/jenkins/plugin/mvnmeta/currentArtifactInfo.txt
@@ -1,0 +1,3 @@
+Artifact ID: my-artifact
+Plugin Version: 3.14159
+Jenkins Version:  42


### PR DESCRIPTION
See [JENKINS-29940](https://issues.jenkins-ci.org/browse/JENKINS-29940):

Near to the versions drop down, the _Maven Metadata Plugin_ should optionally provide an information about the currently used artifact version - which e.g. was selected with the last build.

Implemented download and display of information about the artifact that is currently used. Three additional fields were added to the build parameter configuration for that: a download URL, an informational label and a regex pattern that allows to display only a part of the downloaded information.