### PR TITLE
Bugfix JENKINS-29567: Invalid artifact URL when packaging is not specified

### DIFF
--- a/src/main/lombok/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition.java
+++ b/src/main/lombok/eu/markov/jenkins/plugin/mvnmeta/MavenMetadataParameterDefinition.java
@@ -128,7 +128,7 @@ public class MavenMetadataParameterDefinition extends ParameterDefinition {
     return versionFilterPattern;
   }
 
-  public String readPackaging() {
+  public String getPackaging() {
     if (StringUtils.isNotBlank(this.packaging)) {
       return this.packaging;
     }
@@ -136,8 +136,8 @@ public class MavenMetadataParameterDefinition extends ParameterDefinition {
   }
 
   private ParameterValue createValue(String version) {
-    return new MavenMetadataParameterValue(getName(), getDescription(), getGroupId(), getArtifactId(), version, readPackaging(),
-        getFullArtifactUrl(getGroupId(), getArtifactId(), version, readPackaging()));
+    return new MavenMetadataParameterValue(getName(), getDescription(), getGroupId(), getArtifactId(), version, getPackaging(),
+        getFullArtifactUrl(getGroupId(), getArtifactId(), version, getPackaging()));
   }
 
   // Create a parameter value from the string given in the CLI.
@@ -196,7 +196,7 @@ public class MavenMetadataParameterDefinition extends ParameterDefinition {
     }
 
     return new MavenMetadataParameterValue(getName(), getDescription(), getGroupId(), getArtifactId(), defaultVersion,
-        readPackaging(), getFullArtifactUrl(getGroupId(), getArtifactId(), defaultVersion, readPackaging()));
+        getPackaging(), getFullArtifactUrl(getGroupId(), getArtifactId(), defaultVersion, getPackaging()));
   }
 
   @Override


### PR DESCRIPTION
See [JENKINS-29567](https://issues.jenkins-ci.org/browse/JENKINS-29567):

Fixed invalid artifact URL that is created when no packaging is specified (which actually means default packaging 'jar').