### PR TITLE
Feature: Improved dev setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,42 @@
 
     <profiles>
         <profile>
+            <!-- Automatically create the base configuration for the Jenkins development workspace when it doesn't exist. -->
+            <id>prepare-developement-workspace</id>
+            <activation>
+                <file>
+                    <missing>${basedir}/work</missing>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>2.7</version>
+                        <executions>
+                            <execution>
+                                <id>workspace-base-configuration</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.basedir}/src/dev/assets/work</directory>
+                                            <filtering>true</filtering>
+                                        </resource>
+                                    </resources>
+                                    <outputDirectory>${project.basedir}/work</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>for-development</id>
             <activation>
                 <activeByDefault>false</activeByDefault>

--- a/src/dev/assets/work/jobs/testjob/config.xml
+++ b/src/dev/assets/work/jobs/testjob/config.xml
@@ -17,8 +17,7 @@
           <versionFilter></versionFilter>
           <sortOrder>DESC</sortOrder>
           <maxVersions></maxVersions>
-          <username></username>
-          <password></password>
+          <credentialsId></credentialsId>
         </eu.markov.jenkins.plugin.mvnmeta.MavenMetadataParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>

--- a/src/dev/assets/work/jobs/testjob/config.xml
+++ b/src/dev/assets/work/jobs/testjob/config.xml
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <eu.markov.jenkins.plugin.mvnmeta.MavenMetadataParameterDefinition>
+          <name>ARTIFACT</name>
+          <description></description>
+          <repoBaseUrl>http://repo.jenkins-ci.org/public</repoBaseUrl>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>${project.artifactId}</artifactId>
+          <packaging>${project.packaging}</packaging>
+          <defaultValue></defaultValue>
+          <versionFilter></versionFilter>
+          <sortOrder>DESC</sortOrder>
+          <maxVersions></maxVersions>
+          <username></username>
+          <password></password>
+        </eu.markov.jenkins.plugin.mvnmeta.MavenMetadataParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers class="vector"/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>echo &quot;Selected artifact:&quot;
+echo &quot;  Group ID:     ${ARTIFACT_GROUP_ID}&quot;
+echo &quot;  Artifact ID:  ${ARTIFACT_ARTIFACT_ID}&quot;
+echo &quot;  Version:      ${ARTIFACT_VERSION}&quot;
+echo &quot;  Type:         ${ARTIFACT_PACKAGING}&quot;
+echo &quot;  Download URL: ${ARTIFACT_ARTIFACT_URL}&quot;
+</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/src/dev/assets/work/jobs/testjob/config.xml
+++ b/src/dev/assets/work/jobs/testjob/config.xml
@@ -17,6 +17,9 @@
           <versionFilter></versionFilter>
           <sortOrder>DESC</sortOrder>
           <maxVersions></maxVersions>
+          <currentArtifactInfoUrl>file://${project.basedir}/work/jobs/testjob/currentArtifactInfo.txt</currentArtifactInfoUrl>
+          <currentArtifactInfoLabel>Currently under development</currentArtifactInfoLabel>
+          <currentArtifactInfoPattern>Plugin Version: ([\S]+)</currentArtifactInfoPattern>
           <credentialsId></credentialsId>
         </eu.markov.jenkins.plugin.mvnmeta.MavenMetadataParameterDefinition>
       </parameterDefinitions>

--- a/src/dev/assets/work/jobs/testjob/currentArtifactInfo.txt
+++ b/src/dev/assets/work/jobs/testjob/currentArtifactInfo.txt
@@ -1,0 +1,3 @@
+Plugin ID: ${project.artifactId}
+Plugin Version: ${project.version}
+Jenkins Core Version:  ${project.parent.version}


### PR DESCRIPTION
I like it when development setups are ready for work when I clone them and don't require me to do further manual step until I can start working. When developing Jenkins plugin, I provide configurations and job(s) that are automatically copied to the working directory of the development setup when the ``work`` is created for the first time. This also allows to delete the working directory and start with a fresh, pre-configured workspace without additional work.

Feel free to merge this i You like it.

**Note**: This already covers the contents of my previous pull requests.